### PR TITLE
Fix start behavior

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -28,7 +28,7 @@ const (
 
 	// PathProxyEvents defines the path for templier proxy websocket events endpoint.
 	// This path is very unlikely to collide with any path used by the app server.
-	PathProxyEvents = "/_templiér/events"
+	PathProxyEvents = "/_templier/events"
 
 	ReverseProxyRetries         = 20
 	ReverseProxyInitialDelay    = 100 * time.Millisecond

--- a/main.go
+++ b/main.go
@@ -241,7 +241,7 @@ func runTemplierServer(
 		conf,
 	)
 	var err error
-	if conf.TLS != nil {
+	if conf.TLS.Cert != "" && conf.TLS.Key != "" {
 		err = http.ListenAndServeTLS(conf.TemplierHost,
 			conf.TLS.Cert, conf.TLS.Key, srv)
 	} else {


### PR DESCRIPTION
This PR fixes 2 issues I had when trying to start templier in my project (https://github.com/bastianwegge/gofiber-templ-bench).

1. the `PathProxyEvents = "/_templier/events"` didn't work for me, since it holds unicode
2. the server was always trying to start with TLS, but I wanted http, so I changed the check for TLS to make more sense