### PR TITLE
fix: Order of `app.go-flags` for build command

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,7 +22,7 @@ import (
 	"github.com/romshark/yamagiconf"
 )
 
-const Version = "0.8.0"
+const Version = "0.8.1"
 
 var config Config
 

--- a/main.go
+++ b/main.go
@@ -611,9 +611,13 @@ func buildServer(
 	filesToBeDeletedBeforeExit.Store(binaryPath)
 
 	args := append(
-		[]string{"build", "-o", binaryPath, conf.App.DirCmd},
+		[]string{"build", "-o", binaryPath},
 		conf.App.GoFlags...,
 	)
+	// Path to the main package directory should be always last
+	// see: https://github.com/romshark/templier/issues/9
+	args = append(args, conf.App.DirCmd)
+
 	buf, err := cmdrun.Run(ctx, conf.App.DirWork, "go", args...)
 	if err != nil {
 		bufStr := string(buf)


### PR DESCRIPTION
Fix order of build command to be able to pass `app.go-flags` properly - see #9 