### PR TITLE
feat: Server unreachable error screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,14 @@ for events and reload or display necessary status information when necessary.
 In the CLI console logs, all Templiér logs are prefixed with 🤖,
 while application server logs are displayed without the prefix.
 
+### Health Check
+
+In order to check the health status of the application server, Templiér keeps sending
+`OPTIONS` requests at the URL specified under the `app.host` config for 100 times
+in 100 millisecond intervals. If the server fails to respond, Templiér considers it
+unhealthy and shows an "server unreachable" error while continuing to try to reach it
+until a newer build is available (code was updated) or the server becomes reachable.
+
 ## Development
 
 Run the tests using `go test -race ./...` and use the latest version of

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -16,45 +16,29 @@ func TestValidateType(t *testing.T) {
 }
 
 func TestSpaceSeparatedList(t *testing.T) {
+	t.Parallel()
+
 	type TestConfig struct {
 		List config.SpaceSeparatedList `yaml:"list"`
 	}
-	for _, td := range []struct {
-		name   string
-		input  string
-		expect config.SpaceSeparatedList
-	}{
-		{
-			name:   "empty",
-			input:  "list:",
-			expect: config.SpaceSeparatedList(nil),
-		},
-		{
-			name:   "empty_explicit",
-			input:  "list: ''",
-			expect: config.SpaceSeparatedList(nil),
-		},
-		{
-			name:   "single",
-			input:  "list: one_item",
-			expect: config.SpaceSeparatedList{"one_item"},
-		},
-		{
-			name:   "spaces",
-			input:  "list: -flag value",
-			expect: config.SpaceSeparatedList{"-flag", "value"},
-		},
-		{
-			name:   "multiline",
-			input:  "list: |\n  first second\n  third\tfourth",
-			expect: config.SpaceSeparatedList{"first", "second", "third", "fourth"},
-		},
-	} {
-		t.Run(td.name, func(t *testing.T) {
-			var actual TestConfig
-			err := yamagiconf.Load(td.input, &actual)
-			require.NoError(t, err)
-			require.Equal(t, td.expect, actual.List)
-		})
+
+	f := func(t *testing.T, input string, expect config.SpaceSeparatedList) {
+		t.Helper()
+		var actual TestConfig
+		err := yamagiconf.Load(input, &actual)
+		require.NoError(t, err)
+		require.Equal(t, expect, actual.List)
 	}
+
+	// Empty.
+	f(t, "list:", config.SpaceSeparatedList(nil))
+	// Empty explicit.
+	f(t, "list: ''", config.SpaceSeparatedList(nil))
+	// Single.
+	f(t, "list: one_item", config.SpaceSeparatedList{"one_item"})
+	// Spaces.
+	f(t, "list: -flag value", config.SpaceSeparatedList{"-flag", "value"})
+	// Multiline.
+	f(t, "list: |\n  first second\n  third\tfourth",
+		config.SpaceSeparatedList{"first", "second", "third", "fourth"})
 }

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -161,6 +161,22 @@ func Infof(f string, v ...any) {
 	fmt.Fprintln(out, "")
 }
 
+// Warnf prints an info line to console.
+func Warnf(f string, v ...any) {
+	if Level() < LogLevelVerbose {
+		return
+	}
+	lock.Lock()
+	defer lock.Unlock()
+	fmt.Fprint(out, LinePrefix)
+	if Level() >= LogLevelDebug {
+		fmt.Fprint(out, time.Now().Format(TimeFormat))
+		fYellow.Fprint(out, " WARNING: ")
+	}
+	fmt.Fprintf(out, f, v...)
+	fmt.Fprintln(out, "")
+}
+
 // Errorf prints an error line to console.
 func Error(msg string) {
 	lock.Lock()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -271,6 +271,9 @@ func (s *Server) newReports() []Report {
 	if m := s.stateTracker.Get(statetrack.IndexExit); m != "" {
 		return []Report{{Subject: "process", Body: m}}
 	}
+	if m := s.stateTracker.Get(statetrack.IndexUnreachable); m != "" {
+		return []Report{{Subject: "connection refused", Body: m}}
+	}
 	for i, w := range s.config.CustomWatchers {
 		if m := s.stateTracker.Get(statetrack.IndexOffsetCustomWatcher + i); m != "" {
 			report = append(report, Report{Subject: string(w.Name), Body: m})

--- a/internal/server/templates.templ
+++ b/internal/server/templates.templ
@@ -49,7 +49,7 @@ templ errpage(
 		<body>
 			for i, c := range content {
 				<h3>{ c.Subject }</h3>
-				<pre>{ c.Body }</pre>
+				<div>{ c.Body }</div>
 				if i+1 != len(content) {
 					<hr/>
 				}

--- a/internal/server/templates_templ.go
+++ b/internal/server/templates_templ.go
@@ -64,7 +64,7 @@ func errpage(
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</h3><pre>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</h3><div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -77,7 +77,7 @@ func errpage(
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</pre>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/internal/statetrack/statetrack.go
+++ b/internal/statetrack/statetrack.go
@@ -11,7 +11,8 @@ const (
 	IndexGolangciLint        = 1
 	IndexGo                  = 2
 	IndexExit                = 3
-	IndexOffsetCustomWatcher = 4
+	IndexUnreachable         = 4
+	IndexOffsetCustomWatcher = 5
 )
 
 func (t *Tracker) ErrIndex() int {
@@ -31,7 +32,8 @@ type Tracker struct {
 	// index 1: golangci-lint errors
 	// index 2: go compiler errors
 	// index 3: process exit code != 0
-	// index 4-end: custom watcher errors
+	// index 4: application server is unreachable
+	// index 5-end: custom watcher errors
 	errMsgBuffer []string
 	lock         sync.Mutex
 	broadcaster  *broadcaster.SignalBroadcaster

--- a/internal/statetrack/statetrack_test.go
+++ b/internal/statetrack/statetrack_test.go
@@ -18,6 +18,7 @@ func TestStateListener(t *testing.T) {
 	require.Zero(t, s.Get(statetrack.IndexGolangciLint))
 	require.Zero(t, s.Get(statetrack.IndexGo))
 	require.Zero(t, s.Get(statetrack.IndexExit))
+	require.Zero(t, s.Get(statetrack.IndexUnreachable))
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -36,6 +37,7 @@ func TestStateListener(t *testing.T) {
 	s.Set(statetrack.IndexGolangciLint, "golangcilint failed")
 	s.Set(statetrack.IndexTempl, "templ failed")
 	s.Set(statetrack.IndexExit, "process exited with code 1")
+	s.Set(statetrack.IndexUnreachable, "process is unreachable")
 	s.Set(statetrack.IndexOffsetCustomWatcher+1, "custom watcher failed")
 
 	wg.Wait() // Wait for the listener goroutine to receive an update
@@ -46,6 +48,7 @@ func TestStateListener(t *testing.T) {
 	require.Equal(t, "golangcilint failed", s.Get(statetrack.IndexGolangciLint))
 	require.Equal(t, "go failed", s.Get(statetrack.IndexGo))
 	require.Equal(t, "process exited with code 1", s.Get(statetrack.IndexExit))
+	require.Equal(t, "process is unreachable", s.Get(statetrack.IndexUnreachable))
 }
 
 func TestStateReset(t *testing.T) {
@@ -56,6 +59,7 @@ func TestStateReset(t *testing.T) {
 	require.Zero(t, s.Get(statetrack.IndexGolangciLint))
 	require.Zero(t, s.Get(statetrack.IndexGo))
 	require.Zero(t, s.Get(statetrack.IndexExit))
+	require.Zero(t, s.Get(statetrack.IndexUnreachable))
 
 	s.Set(statetrack.IndexGo, "go failed")
 	s.Set(statetrack.IndexGolangciLint, "golangcilint failed")
@@ -67,6 +71,7 @@ func TestStateReset(t *testing.T) {
 	require.Zero(t, s.Get(statetrack.IndexGolangciLint))
 	require.Zero(t, s.Get(statetrack.IndexGo))
 	require.Zero(t, s.Get(statetrack.IndexExit))
+	require.Zero(t, s.Get(statetrack.IndexUnreachable))
 
 	require.Equal(t, -1, s.ErrIndex())
 }


### PR DESCRIPTION
Improve UX by considering the application server "unreachable" and displaying an according error message on screen if it remains unreachable after a considerable amount of time, yet  continue to try to reach it but restart health check if a newer build is available.