### PR TITLE
fix(engine,cmdrun): unstick build pipeline from canceled rebuilds and templ warnings

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -547,6 +547,14 @@ func (e *Engine) runAppLauncher(
 				rerun(ctx)
 			})
 		case newBinaryPath := <-e.chRunNewServer:
+			if newBinaryPath == "" {
+				// Defensive: recompile() should already filter empty
+				// paths, but if anything ever forwards one here we
+				// must not overwrite latestBinaryPath with "" or call
+				// rerun, which would exec("") → "exec: no command".
+				e.logger.Debug("ignoring empty binary path on chRunNewServer")
+				continue
+			}
 			runner.Go(ctx, func(ctx context.Context) {
 				if latestBinaryPath != "" {
 					e.logger.Debug("remove executable", "path", latestBinaryPath)
@@ -721,6 +729,13 @@ func (h *fileChangeHandler) recompile(ctx context.Context, e fsnotify.Event) {
 			)
 			if h.stateTracker.ErrIndex() != -1 {
 				h.reload.BroadcastNonblock()
+				return
+			}
+			if newBinaryPath == "" {
+				// Build was superseded (ctx canceled by a newer
+				// recompile). Forwarding an empty path would make
+				// the launcher exec("") and loop on
+				// "exec: no command".
 				return
 			}
 			h.engine.chRunNewServer <- newBinaryPath

--- a/engine/handler_test.go
+++ b/engine/handler_test.go
@@ -1,10 +1,14 @@
 package engine
 
 import (
+	"bytes"
 	"context"
 	"log/slog"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -105,4 +109,192 @@ func TestCustomWatcherOnExcludedDir(t *testing.T) {
 		}
 		t.Fatal("handler was called but custom watcher did not trigger a reload")
 	}
+}
+
+// TestRunAppLauncherIgnoresEmptyBinaryPath reproduces Bug B:
+// a superseded build returns "" from buildServer (ctx canceled).
+// Pre-fix, the launcher would set latestBinaryPath = "" and call
+// exec.Command(""), logging "exec: no command" on every rerun.
+// The fix drops empty paths at the chRunNewServer case so the
+// launcher never enters that state.
+func TestRunAppLauncherIgnoresEmptyBinaryPath(t *testing.T) {
+	var logBuf bytes.Buffer
+	var logMu sync.Mutex
+	logger := slog.New(slog.NewTextHandler(
+		&syncWriter{w: &logBuf, mu: &logMu},
+		&slog.HandlerOptions{Level: slog.LevelDebug},
+	))
+
+	appHost, err := url.Parse("http://127.0.0.1:1")
+	require.NoError(t, err)
+
+	e := &Engine{
+		conf: Config{
+			App: AppConfig{
+				DirCmd:  "./cmd/server/",
+				DirWork: t.TempDir(),
+				Host:    appHost,
+			},
+		},
+		logger:         logger,
+		stdout:         &bytes.Buffer{},
+		stderr:         &bytes.Buffer{},
+		chRerunServer:  make(chan struct{}, 1),
+		chRunNewServer: make(chan string, 1),
+	}
+
+	st := statetrack.NewTracker(0)
+	reload := broadcaster.NewSignalBroadcaster()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		e.runAppLauncher(ctx, st, reload)
+		close(done)
+	}()
+
+	// Push the empty path the way a canceled build would. Before the fix
+	// this would trigger exec.Command("") and log "exec: no command".
+	e.chRunNewServer <- ""
+
+	// Give the launcher a chance to process it.
+	time.Sleep(150 * time.Millisecond)
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runAppLauncher did not exit after ctx cancel")
+	}
+
+	logMu.Lock()
+	out := logBuf.String()
+	logMu.Unlock()
+
+	if strings.Contains(out, "exec: no command") {
+		t.Fatalf("launcher tried to exec empty binary path; logs:\n%s", out)
+	}
+	if strings.Contains(out, "running app server") {
+		t.Fatalf("launcher attempted to start app from empty path; logs:\n%s", out)
+	}
+	require.Contains(t, out, "ignoring empty binary path",
+		"expected the empty-path guard to fire")
+}
+
+// TestRecompileDoesNotForwardEmptyPath reproduces the upstream half of
+// Bug B: when a build is canceled by a newer recompile, buildServer
+// returns "" and no IndexGo state is set (it's a cancel, not a failure).
+// The recompile callback must NOT forward that empty path to
+// chRunNewServer — otherwise the launcher would exec("").
+//
+// We trigger the cancellation by causing the build context to be
+// canceled mid-flight via the buildRunner: a second recompile call
+// cancels the first. With a build that takes long enough for the
+// second call to land first, the first build returns "" through the
+// canceled path. We then assert nothing empty arrives on
+// chRunNewServer.
+func TestRecompileDoesNotForwardEmptyPath(t *testing.T) {
+	dir := t.TempDir()
+	cmdDir := filepath.Join(dir, "cmd", "server")
+	require.NoError(t, os.MkdirAll(cmdDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
+		[]byte("module testapp\n\ngo 1.21\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(cmdDir, "main.go"),
+		[]byte("package main\nfunc main(){}\n"), 0o644))
+
+	// buildServer invokes `go build` with workDir="" so DirCmd resolves
+	// against the process cwd. Chdir into the synthetic project for the
+	// duration of the test.
+	origCwd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origCwd) })
+
+	appHost, perr := url.Parse("http://127.0.0.1:1")
+	require.NoError(t, perr)
+
+	e := &Engine{
+		conf: Config{
+			App: AppConfig{
+				DirCmd:     "./cmd/server/",
+				DirSrcRoot: dir,
+				DirWork:    dir,
+				Host:       appHost,
+			},
+		},
+		logger: slog.New(slog.DiscardHandler),
+		stdout:         &bytes.Buffer{},
+		stderr:         &bytes.Buffer{},
+		chRerunServer:  make(chan struct{}, 1),
+		chRunNewServer: make(chan string, 16),
+	}
+
+	st := statetrack.NewTracker(0)
+	reload := broadcaster.NewSignalBroadcaster()
+
+	h := &fileChangeHandler{
+		engine:            e,
+		binaryOutBasePath: t.TempDir(),
+		watchBasePath:     dir,
+		stateTracker:      st,
+		reload:            reload,
+		debounced:         func(fn func()) { fn() },
+		buildRunner:       ctxrun.New(),
+	}
+
+	ctx := context.Background()
+
+	// Kick off many recompiles back-to-back so most of them get their
+	// contexts canceled by the next. The first N-1 should return ""
+	// from buildServer via the ctx-canceled path; only the last build
+	// (whichever wins) is allowed to forward a path.
+	const iterations = 6
+	for i := 0; i < iterations; i++ {
+		h.recompile(ctx, fsnotify.Event{Name: "x.go"})
+	}
+
+	// Drain chRunNewServer for a window long enough to outlast any
+	// in-flight build of the tiny test app, plus a grace period for
+	// any (buggy) empty sends from canceled builds.
+	deadline := time.After(15 * time.Second)
+	var paths []string
+loop:
+	for {
+		select {
+		case p := <-e.chRunNewServer:
+			paths = append(paths, p)
+			if p != "" {
+				// Give a short tail to catch any straggling empty
+				// sends that would have followed a real build.
+				select {
+				case extra := <-e.chRunNewServer:
+					paths = append(paths, extra)
+				case <-time.After(500 * time.Millisecond):
+				}
+				break loop
+			}
+		case <-deadline:
+			break loop
+		}
+	}
+
+	for i, p := range paths {
+		if p == "" {
+			t.Fatalf("recompile forwarded empty path at index %d "+
+				"(all paths: %v)", i, paths)
+		}
+	}
+	require.NotEmpty(t, paths,
+		"expected at least one successful build to forward a non-empty path")
+}
+
+type syncWriter struct {
+	w  *bytes.Buffer
+	mu *sync.Mutex
+}
+
+func (s *syncWriter) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.w.Write(p)
 }

--- a/internal/cmdrun/cmdrun.go
+++ b/internal/cmdrun/cmdrun.go
@@ -107,30 +107,7 @@ func RunTemplWatch(
 		// Read the command output
 		scanner := bufio.NewScanner(stdout)
 		for scanner.Scan() {
-			b := scanner.Bytes()
-			logger.Debug("templ", "output", string(b))
-			switch {
-			case bytes.HasPrefix(b, bytesPrefixWarning):
-				st.Set(statetrack.IndexTempl, scanner.Text())
-			case bytes.HasPrefix(b, bytesPrefixErr):
-				st.Set(statetrack.IndexTempl, scanner.Text())
-			case bytes.HasPrefix(b, bytesPrefixErrCleared):
-				st.Set(statetrack.IndexTempl, "")
-			}
-			if after, found := bytes.CutPrefix(b, bytesPrefixPostGenEvent); found {
-				switch {
-				case bytes.Contains(after, bytesNeedsRestart):
-					select {
-					case templChange <- TemplChangeNeedsRestart:
-					default:
-					}
-				case bytes.Contains(after, bytesNeedsBrowserReload):
-					select {
-					case templChange <- TemplChangeNeedsBrowserReload:
-					default:
-					}
-				}
-			}
+			handleTemplOutputLine(scanner.Bytes(), logger, st, templChange)
 		}
 		if err := scanner.Err(); err != nil {
 			logger.Error("scanning templ watch output", "err", err)
@@ -150,6 +127,48 @@ func RunTemplWatch(
 		return err
 	}
 	return nil
+}
+
+// handleTemplOutputLine classifies one line from `templ generate --watch`
+// stdout and updates state / change channels accordingly.
+//
+// Warnings ("(!)") are intentionally not written to IndexTempl. Templ
+// emits them for benign conditions (version-check FYIs, deprecation
+// notes, "templ not found in go.mod" for non-templ projects, CLI vs
+// go.mod version skew). The engine treats any non-empty IndexTempl as
+// a hard error that gates initial build and every subsequent rebuild,
+// so conflating warnings with errors silently disables templier
+// whenever templ has anything chatty to say. Only "(✗)" lines are
+// actual generator errors.
+func handleTemplOutputLine(
+	b []byte,
+	logger *slog.Logger,
+	st *statetrack.Tracker,
+	templChange chan<- TemplChange,
+) {
+	logger.Debug("templ", "output", string(b))
+	switch {
+	case bytes.HasPrefix(b, bytesPrefixWarning):
+		logger.Warn("templ", "output", string(b))
+	case bytes.HasPrefix(b, bytesPrefixErr):
+		st.Set(statetrack.IndexTempl, string(b))
+	case bytes.HasPrefix(b, bytesPrefixErrCleared):
+		st.Set(statetrack.IndexTempl, "")
+	}
+	if after, found := bytes.CutPrefix(b, bytesPrefixPostGenEvent); found {
+		switch {
+		case bytes.Contains(after, bytesNeedsRestart):
+			select {
+			case templChange <- TemplChangeNeedsRestart:
+			default:
+			}
+		case bytes.Contains(after, bytesNeedsBrowserReload):
+			select {
+			case templChange <- TemplChangeNeedsBrowserReload:
+			default:
+			}
+		}
+	}
 }
 
 var (

--- a/internal/cmdrun/cmdrun_test.go
+++ b/internal/cmdrun/cmdrun_test.go
@@ -1,0 +1,107 @@
+package cmdrun
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/romshark/templier/internal/statetrack"
+
+	"github.com/stretchr/testify/require"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// TestHandleTemplOutputLineWarningDoesNotGateBuilds covers Bug A.
+//
+// Templ uses two distinct prefixes on stdout: "(!)" for warnings and
+// "(✗)" for errors. The engine treats any non-empty IndexTempl as a
+// fatal templ error and skips `go build` (initial and subsequent).
+// Pre-fix, both prefixes were written into IndexTempl, so any chatty
+// warning from templ silently disabled the entire build pipeline:
+//
+//   - "(!) templ version check: templ not found in go.mod file..." for
+//     projects not importing a-h/templ.
+//   - "(!) templ version check: generator vX is older than templ
+//     version vY found in go.mod file..." for CLI vs go.mod skew.
+//
+// Both are FYIs, not errors. Only "(✗)" lines should populate
+// IndexTempl.
+func TestHandleTemplOutputLineWarningDoesNotGateBuilds(t *testing.T) {
+	cases := []string{
+		"(!) templ version check: templ not found in go.mod file, " +
+			"run `go get github.com/a-h/templ` to install it",
+		"(!) templ version check: generator v0.3.1001 is older than " +
+			"templ version v0.3.1020 found in go.mod file, " +
+			"consider upgrading templ CLI",
+	}
+	for _, line := range cases {
+		t.Run(line[:20], func(t *testing.T) {
+			st := statetrack.NewTracker(0)
+			ch := make(chan TemplChange, 1)
+
+			handleTemplOutputLine([]byte(line), discardLogger(), st, ch)
+
+			require.Empty(t, st.Get(statetrack.IndexTempl),
+				"warning must not populate IndexTempl — that would gate the build")
+			require.Equal(t, -1, st.ErrIndex(),
+				"ErrIndex must remain -1 after a warning")
+		})
+	}
+}
+
+func TestHandleTemplOutputLineError(t *testing.T) {
+	st := statetrack.NewTracker(0)
+	ch := make(chan TemplChange, 1)
+
+	line := []byte("(✗) Error generating: ./bad.templ:1:2 syntax error")
+	handleTemplOutputLine(line, discardLogger(), st, ch)
+
+	require.Equal(t, string(line), st.Get(statetrack.IndexTempl))
+	require.Equal(t, statetrack.IndexTempl, st.ErrIndex())
+}
+
+func TestHandleTemplOutputLineErrorCleared(t *testing.T) {
+	st := statetrack.NewTracker(0)
+	st.Set(statetrack.IndexTempl, "previous error")
+	ch := make(chan TemplChange, 1)
+
+	handleTemplOutputLine(
+		[]byte("(✓) Error cleared"), discardLogger(), st, ch,
+	)
+	require.Empty(t, st.Get(statetrack.IndexTempl))
+}
+
+func TestHandleTemplOutputLinePostGenRestart(t *testing.T) {
+	st := statetrack.NewTracker(0)
+	ch := make(chan TemplChange, 1)
+
+	handleTemplOutputLine(
+		[]byte("(✓) Post-generation event received, processing... needsRestart=true"),
+		discardLogger(), st, ch,
+	)
+	select {
+	case got := <-ch:
+		require.Equal(t, TemplChangeNeedsRestart, got)
+	default:
+		t.Fatal("expected a TemplChangeNeedsRestart signal")
+	}
+}
+
+func TestHandleTemplOutputLinePostGenReload(t *testing.T) {
+	st := statetrack.NewTracker(0)
+	ch := make(chan TemplChange, 1)
+
+	handleTemplOutputLine(
+		[]byte("(✓) Post-generation event received, processing... needsBrowserReload=true"),
+		discardLogger(), st, ch,
+	)
+	select {
+	case got := <-ch:
+		require.Equal(t, TemplChangeNeedsBrowserReload, got)
+	default:
+		t.Fatal("expected a TemplChangeNeedsBrowserReload signal")
+	}
+}


### PR DESCRIPTION
> [!NOTE]
> Disclosure: This PR was created with the help of AI

While running templier against a pure-Go project with a Tailwind custom-watcher, I ran into two separate failure modes that both end the same way: templier sits there looking healthy, but the app server never comes up and nothing in the logs tells you why, and an `exec` error loop. They're independent bugs, but they're easy to hit together, so I'm fixing both here.

## Bug 1: empty binary paths leak into the launcher

When a rebuild is superseded during a build (you saved another file before the first build finished), `ctxrun` cancels the in-flight build's context. `buildServer` handles that correctly and returns `""` with no error state.

The problem is what happens next. The `recompile` callback only checks `stateTracker.ErrIndex() != -1` before forwarding the result, so the empty string goes through into `chRunNewServer`. The launcher stores it as `latestBinaryPath` and feeds it to `exec.Command("")`, which fails with `exec: no command`. Since `latestBinaryPath` is now `""`, every subsequent rerun does the same thing, forever:

```
ERR running app server cmd=./cmd/server/ err=exec: no command
ERR health check: waiting for process err=exec: not started
```

You only really see this when something rapid-fires file events at templier. The trigger I hit was the doublestar migration in v0.11.0: the old `gobwas/glob` semantics let `exclude: ["public/*"]` cover `public/css/app.css`, but under doublestar a single `*` doesn't cross `/` anymore. So my Tailwind output stopped being excluded, every CSS write cancelled the in-flight Go build, and the launcher locked itself into the loop above.

### Reproduce

1. Set up a project with a custom-watcher whose output isn't actually covered by the main watcher's `exclude` (the `public/*` vs `public/**` pattern above is the easy one).
2. Edit any source file. The first build starts, the custom-watcher write supersedes it.
3. Within ~30s of the initial app start, the `exec: no command` log starts looping.

## Bug 2: templ `(!)` warnings silently disable the build pipeline

`templ generate --watch` prefixes its stdout lines: `(✗)` for errors, `(!)` for warnings. The watcher in `cmdrun.go` was treating both the same way — writing them straight into `statetrack.IndexTempl`. But the engine reads `IndexTempl` as a hard error signal: if it's non-empty, `lintAndBuildServer` exits before `go build` and `handle()` suppresses subsequent rebuilds.

In practice, you don't have to do anything weird to trigger this. Two warnings I hit during normal use:

- `(!) templ version check: templ not found in go.mod file, run \`go get github.com/a-h/templ\` to install it`
- `(!) templ version check: generator v0.3.1001 is older than templ version v0.3.1020 found in go.mod file, consider upgrading templ CLI`

The first only really applies if you're not using templ at all (a fair thing to warn about), but the second can happen to anyone with even slightly mismatched tool versions, and there's no way to know it's silently breaking templier unless you crank up `log.level: debug` and notice that "compiled cmd/server" never shows up.

### Reproduce

1. Get templ to emit any `(!)` line at startup. The easiest path is a CLI/go.mod version skew: install one templ version, pin a different one in `go.mod`.
2. Run templier with `log.level: debug`.
3. You'll see the `(!)` line, then `templier started`, then nothing. `go build` never runs; the configured app host stays down.

## What the patch does

- **engine**: `recompile` now drops empty paths before sending to `chRunNewServer`, and `runAppLauncher` has a defensive skip so `latestBinaryPath` can never be clobbered with `""` even if some future caller forwards one.
- **cmdrun**: warnings now log at `warn` level instead of being written into `IndexTempl`. Only `(✗)` lines populate it, which matches templ's own distinction between the two prefixes. The per-line parser is extracted into `handleTemplOutputLine` so the branches can be unit-tested directly.
- **tests**: regression coverage for both layers of bug 1 (`engine/handler_test.go`) and both warning variants of bug 2 plus the other parser branches (`internal/cmdrun/cmdrun_test.go`).

Details are in the diff.