### PR TITLE
Make the templ command configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,10 @@ to rebuild the server. Restarting it may be sufficient:
 
 Templiér acts as a file watcher, proxy server and process manager.
 Once Templiér is started, it runs `templ generate --watch` in the background and begins
-watching files in the `app.dir-src-root` directory.
+watching files in the `app.dir-src-root` directory. The command used to run templ
+(both for `generate --watch` and `fmt`) can be configured via `templ-cmd`, which
+defaults to `templ`. Set it to `go tool templ` if you have templ installed as a
+Go tool dependency instead of a system-wide binary.
 On start, it runs all configured custom watchers and then builds your application server
 executable in the OS temp directory (cleaned up on exit at the latest), assuming that
 the main package is specified by the `app.dir-cmd` directory.

--- a/engine/config.go
+++ b/engine/config.go
@@ -93,6 +93,12 @@ type Config struct {
 	// Example: "127.0.0.1:9999".
 	TemplierHost string
 
+	// TemplCmd is the command used to run templ for code generation
+	// and formatting. Empty means ["templ"]. Set to ["go", "tool", "templ"]
+	// to use a templ binary installed as a Go tool dependency instead of a
+	// system-wide installation.
+	TemplCmd []string
+
 	// TLS enables TLS for the templier proxy server. Nil means plain HTTP.
 	TLS *TLSConfig
 
@@ -258,8 +264,9 @@ func (c *Config) Validate() error {
 	}
 
 	// Check required binaries.
-	if _, err := exec.LookPath("templ"); err != nil {
-		return fmt.Errorf("engine: templ is not installed or not in PATH: %w", err)
+	if _, err := exec.LookPath(c.TemplCmd[0]); err != nil {
+		return fmt.Errorf("engine: templ command %q is not installed or not in PATH: %w",
+			c.TemplCmd[0], err)
 	}
 	if c.Lint {
 		if _, err := exec.LookPath("golangci-lint"); err != nil {
@@ -310,5 +317,8 @@ func (c *Config) applyDefaults() {
 	}
 	if c.ReconnectMessage == "" {
 		c.ReconnectMessage = "reconnecting..."
+	}
+	if len(c.TemplCmd) == 0 {
+		c.TemplCmd = []string{"templ"}
 	}
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -156,7 +156,7 @@ func (e *Engine) Run(ctx context.Context) error {
 		defer wg.Done()
 		// Run templ in watch mode to create debug components.
 		err := cmdrun.RunTemplWatch(
-			ctx, e.conf.App.DirSrcRoot, e.logger, st, templChange,
+			ctx, e.conf.App.DirSrcRoot, e.conf.TemplCmd, e.logger, st, templChange,
 		)
 		if err != nil && !errors.Is(err, context.Canceled) {
 			err = fmt.Errorf("running templ generate watch mode: %w", err)
@@ -614,7 +614,8 @@ func (h *fileChangeHandler) handle(ctx context.Context, e fsnotify.Event) error 
 	if h.engine.conf.Format && e.Op != fsnotify.Remove && e.Op != fsnotify.Rename {
 		if strings.HasSuffix(e.Name, ".templ") {
 			h.engine.logger.Debug("format templ file", "name", e.Name)
-			if err := cmdrun.RunTemplFmt(ctx, h.engine.conf.App.DirWork, e.Name); err != nil {
+			templCmd := h.engine.conf.TemplCmd
+			if err := cmdrun.RunTemplFmt(ctx, h.engine.conf.App.DirWork, templCmd, e.Name); err != nil {
 				h.engine.logger.Error("templ formatting error", "err", err)
 			}
 		}
@@ -828,7 +829,8 @@ func (e *Engine) lintAndBuildServer(
 }
 
 func (e *Engine) checkTemplVersion(ctx context.Context) error {
-	out, err := cmdrun.Run(ctx, "", nil, e.logger, "templ", "version")
+	args := append(append([]string{}, e.conf.TemplCmd[1:]...), "version")
+	out, err := cmdrun.Run(ctx, "", nil, e.logger, e.conf.TemplCmd[0], args...)
 	if err != nil {
 		return err
 	}

--- a/example-config.yml
+++ b/example-config.yml
@@ -12,6 +12,13 @@ format: true
 # templier-host defines what host address to run Templiér on.
 templier-host: "your-application:11000"
 
+# templ-cmd defines the command used to run templ for code generation
+# and formatting. Defaults to "templ" which requires templ to be
+# installed and available in your $PATH.
+# Use "go tool templ" instead if you have templ installed as a Go tool
+# dependency (see: https://go.dev/blog/tools.go).
+templ-cmd: templ
+
 log:
   # level allows you to chose from different log levels:
   #  "" (empty): same as erronly.

--- a/internal/cmdrun/cmdrun.go
+++ b/internal/cmdrun/cmdrun.go
@@ -54,9 +54,9 @@ func Sh(ctx context.Context, workDir string, logger *slog.Logger, sh string) (ou
 	return Run(ctx, workDir, nil, logger, "sh", "-c", sh)
 }
 
-// RunTemplFmt runs `templ fmt <path>`.
-func RunTemplFmt(ctx context.Context, workDir string, path string) error {
-	cmd := exec.Command("templ", "fmt", "-fail", path)
+// RunTemplFmt runs `<templCmd> fmt <path>`.
+func RunTemplFmt(ctx context.Context, workDir string, templCmd []string, path string) error {
+	cmd := exec.CommandContext(ctx, templCmd[0], append(templCmd[1:], "fmt", "-fail", path)...)
 	cmd.Dir = workDir
 	return cmd.Run()
 }
@@ -69,27 +69,29 @@ const (
 	TemplChangeNeedsBrowserReload
 )
 
-// RunTemplWatch starts `templ generate --log-level debug --watch` and reads its
+// RunTemplWatch starts `<templCmd> generate --log-level debug --watch` and reads its
 // stdout pipe for failure and success logs updating the state accordingly.
 // When ctx is canceled the interrupt signal is sent to the watch process
 // and graceful shutdown is awaited.
 func RunTemplWatch(
 	ctx context.Context,
 	workDir string,
+	templCmd []string,
 	logger *slog.Logger,
 	st *statetrack.Tracker,
 	templChange chan<- TemplChange,
 ) error {
 	// Don't use CommandContext since it will kill the process
 	// which we don't want. We want the command to finish.
-	cmd := exec.Command(
-		"templ", "generate",
+	args := append(append([]string{}, templCmd[1:]...),
+		"generate",
 		"--watch",
 		"--log-level", "debug",
 		// Disable Templ's new native Go watcher to avoid any collisions
 		// since Templier is already watching .go file changes.
 		"--watch-pattern", `(.+\.templ$)`,
 	)
+	cmd := exec.Command(templCmd[0], args...)
 	cmd.Dir = workDir
 
 	stdout, err := cmd.StderrPipe()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,6 +51,12 @@ type Config struct {
 	// Example: "127.0.0.1:9999".
 	TemplierHost string `yaml:"templier-host" validate:"hostname_port,required"`
 
+	// TemplCmd defines the command used to run templ.
+	// Defaults to "templ" but can be set to "go tool templ" to use the
+	// templ binary installed as a Go tool dependency instead of a
+	// system-wide installation.
+	TemplCmd SpaceSeparatedList `yaml:"templ-cmd"`
+
 	// TLS is optional, will serve HTTP instead of HTTPS if nil.
 	TLS *struct {
 		Cert string `yaml:"cert" validate:"filepath,required"`
@@ -379,6 +385,7 @@ func MustParse(version, commit, date string) engine.Config {
 	conf.Log.ClearOn = LogClearDisabled
 	conf.Log.PrintJSDebugLogs = false
 	conf.TLS = nil
+	conf.TemplCmd = SpaceSeparatedList{"templ"}
 
 	if fConfigPath == "" {
 		// Try to detect config automatically.
@@ -457,6 +464,7 @@ func toEngineConfig(c *Config) engine.Config {
 		Lint:          c.Lint,
 		Format:        c.Format,
 		TemplierHost:  c.TemplierHost,
+		TemplCmd:      []string(c.TemplCmd),
 		WatcherIgnore: []string(c.WatcherIgnore),
 		Log: engine.LogConfig{
 			Level:            engine.LogLevel(c.Log.Level),


### PR DESCRIPTION
## Summary
- Adds a new `templ-cmd` config option (defaults to `templ`) that defines the command used to run templ for `generate --watch` and `fmt`.
- This allows using `go tool templ` instead of relying on a system-wide `templ` binary, e.g. when templ is managed as a Go tool dependency.

## Changes
- `internal/config/config.go`: new `Config.TemplCmd` field (`SpaceSeparatedList`, default `["templ"]`).
- `internal/cmdrun/cmdrun.go`: `RunTemplFmt` and `RunTemplWatch` now accept the configured command/args instead of hardcoding `"templ"`.
- `main.go`: pass `conf.TemplCmd` at both call sites.
- `example-config.yml` and `README.md`: document the new option.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`